### PR TITLE
Adds the jacoco maven plugin for code coverage

### DIFF
--- a/CODE_COVERAGE.md
+++ b/CODE_COVERAGE.md
@@ -1,0 +1,7 @@
+# Code Coverage Report generation
+
+To generate the code coverage report, execute the following command:
+> mvn clean verify
+
+This will generate code coverage report in the target folder
+> target/site/jacoco/index.html

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,14 @@
   </distributionManagement>
 
   <dependencies>
-  
+
 	<!-- GSON -->
   	<dependency>
 	    <groupId>com.google.code.gson</groupId>
 	    <artifactId>gson</artifactId>
 	    <version>2.3</version>
 	</dependency>
-	
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -41,19 +41,38 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
    	<plugins>
-	  
-	  <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-        <configuration>
-            <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-        </configuration>
-     </plugin>
-	  
-	  <plugin>
+        <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8.2</version>
+            <configuration>
+                <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+            </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.5.201505241946</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>report</id>
+                    <phase>prepare-package</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+
+        <plugin>
             <groupId>com.github.github</groupId>
             <artifactId>site-maven-plugin</artifactId>
             <version>0.10</version>
@@ -76,8 +95,7 @@
               </execution>
             </executions>
         </plugin>
-	  
   	</plugins>
   </build>
-  
+
 </project>


### PR DESCRIPTION
Added the jacoco maven plugin for code coverage. 
Just execute `mvn clean verify`
Result is placed in target folder 
Having good code coverage will definitely help when refactoring the client :smile:
@matsjj let me know if I can give you a hand with increasing test coverage :smile: 
Have you considered setting up the project on Travis and Coveralls?