### PR TITLE
Correction of Chart.java to parse correctly JSON response.

### DIFF
--- a/src/main/java/info/blockchain/api/statistics/Chart.java
+++ b/src/main/java/info/blockchain/api/statistics/Chart.java
@@ -38,7 +38,7 @@ public class Chart {
 
     private List<Point> getPoints(JsonObject chartJson) {
         List<Point> points = new ArrayList<Point>();
-        for (JsonElement pointElement : chartJson.getAsJsonArray()) {
+        for (JsonElement pointElement : chartJson.getAsJsonArray("values")) {
             JsonObject pointJson = pointElement.getAsJsonObject();
             points.add(new Point(pointJson));
         }


### PR DESCRIPTION
Can't find the json array in charJson variable. Need to precise which field contains the array in charJson var.
The array which contains values is in _values_ field of JSON response.